### PR TITLE
Corrected line 253 DEVICeTYPE

### DIFF
--- a/rpi4-usb.sh
+++ b/rpi4-usb.sh
@@ -250,7 +250,7 @@ PS3="$prompt "
 select opt in "${options[@]}" ; do 
     case "$REPLY" in
     1) DEVICETYPE="net-rndis";break;;
-    2) DEVICeTYPE="net-ecm";break;;
+    2) DEVICETYPE="net-ecm";break;;
     *) echo "Invalid option. Try another one.";continue;;
     esac
 done


### PR DESCRIPTION
In line 253 of rpi4-usb.sh, for selection of ECM or RNDIS network type, variable DEVICeTYPE for ECM is incorrectly spelled, so when selecting option 1 or 2, both will configure "net-rndis". This PR corrects line 253 so that "net-ecm" can be selected properly. I have tested this locally and was able to select the correct network type when choosing option 1 or 2.