### PR TITLE
Add missing line to usb0 interfaces file

### DIFF
--- a/rpi4-usb.sh
+++ b/rpi4-usb.sh
@@ -185,6 +185,7 @@ EOF
         cat << EOF | sudo tee /etc/network/interfaces.d/usb0 > /dev/null
 auto usb0
 allow-hotplug usb0
+iface usb0 inet static
   address $BASE_IP.1
   netmask $NETMASK
 EOF


### PR DESCRIPTION
As mentioned in Issue #9 I added the missing line to the usb0 interfaces file in /etc/network/interfaces.d/usb0